### PR TITLE
Fix spiff binary creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,26 +72,9 @@ jobs:
           echo "Compiling ${{github.repository}}..."
           arduino-cli compile -v -b esp32:esp32:esp32 --output-dir build ESP32-SOCKETIO
 
-      - name: Checkout mkspiffs
-        uses: actions/checkout@v2
-        with:
-          repository: igrr/mkspiffs
-          path: mkspiffs
-
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y make gcc build-essential
-          find / -name "mkspiffs" 
-
-      - name: Build mkspiffs
-        run: |
-          cd mkspiffs && git submodule update --init && make dist
-          cd .. && mkspiffs/./mkspiffs --version
-
       - name: Create spiffs binary
         run: |
-          mkspiffs/./mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x100000 build/spiffs.bin
+          /home/runner/.arduino15/packages/esp32/tools/mkspiffs/0.2.3/mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x100000 build/spiffs.bin
 
       - name: Checkout esp_binary_merger
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y make gcc build-essential
+          find / -name "mkspiffs" 
 
       - name: Build mkspiffs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create spiffs binary
         run: |
-          mkspiffs/./mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x100000 build/spiffs.bin
+          mkspiffs/./mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x290000 build/spiffs.bin
 
       - name: Checkout esp_binary_merger
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create spiffs binary
         run: |
-          mkspiffs/./mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x290000 build/spiffs.bin
+          mkspiffs/./mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x100000 build/spiffs.bin
 
       - name: Checkout esp_binary_merger
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Create spiffs binary
         run: |
-          /home/runner/.arduino15/packages/esp32/tools/mkspiffs/0.2.3/mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x100000 build/spiffs.bin
+          /home/runner/.arduino15/packages/esp32/tools/mkspiffs/0.2.3/mkspiffs -c ESP32-SOCKETIO/data -b 4096 -p 256 -s 0x170000 build/spiffs.bin
 
       - name: Checkout esp_binary_merger
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes for issue #26. Also now using mkspiffs bundled with esp32 tools rather than building from scratch.