### PR TITLE
change connect to wifi behaviour to kick up captive portal every time

### DIFF
--- a/ESP32-SOCKETIO.ino
+++ b/ESP32-SOCKETIO.ino
@@ -36,7 +36,7 @@ int currentSetupStatus = setup_pending;
 #define PROJECT_SLUG "ESP32-SOCKETIO"
 #define VERSION "v0.2"
 #define ESP32set
-#define WIFICONNECTTIMEOUT 60000
+#define WIFICONNECTTIMEOUT 120000
 #define SSID_MAX_LENGTH 31
 
 #include <AsyncTCP.h>

--- a/ESP32-SOCKETIO.ino
+++ b/ESP32-SOCKETIO.ino
@@ -73,7 +73,7 @@ using namespace ace_button;
 #define RGBLEDPWMSTART 120
 #define FASTLONGFADE 120
 unsigned long LONGFADEMINUTESMAX = 360;
-#define LONGFADECHECKMILLIS 60000
+#define LONGFADECHECKMILLIS 120000
 unsigned long  prevLongFadeVal[NUMPIXELS] = {0,0};
 uint8_t hue[NUMPIXELS];
 uint8_t saturation[NUMPIXELS];

--- a/wifi.ino
+++ b/wifi.ino
@@ -84,10 +84,6 @@ void connectToWifi(String credentials) {
   long wifiMillis = millis();
   bool connectSuccess = false;
 
-  preferences.begin("scads", false);
-  bool hasConnected = preferences.getBool("hasConnected");
-  preferences.end();
-
   while (!connectSuccess) {
 
     uint8_t currentStatus = wifiMulti.run();
@@ -121,13 +117,6 @@ void connectToWifi(String credentials) {
 
     if (currentStatus == WL_CONNECTED) {
       // Connected!
-
-      if (!hasConnected) {
-        preferences.begin("scads", false);
-        preferences.putBool("hasConnected", true);
-        preferences.end();
-        hasConnected = true;
-      }
       connectSuccess = true;
       break;
     }

--- a/wifi.ino
+++ b/wifi.ino
@@ -72,7 +72,7 @@ void connectToWifi(String credentials) {
   if (ssid.size() > 0) {
     for (int i = 0; i < ssid.size(); i++) {
       if (isWifiValid(ssid[i])) {
-      wifiMulti.addAP(checkSsidForSpelling(ssid[i]).c_str(), pass[i]);
+        wifiMulti.addAP(checkSsidForSpelling(ssid[i]).c_str(), pass[i]);
       }
     }
   } else {
@@ -134,31 +134,12 @@ void connectToWifi(String credentials) {
 
     if (millis() - wifiMillis > WIFICONNECTTIMEOUT) {
       // Timeout, check if we're out of range.
-      while (hasConnected) {
-        // Out of range, keep trying
-        uint8_t _currentStatus = wifiMulti.run();
-        if (_currentStatus == WL_CONNECTED) {
-          digitalWrite(LED_BUILTIN, 0);
-          preferences.begin("scads", false);
-          preferences.putBool("hasConnected", true);
-          preferences.end();
-          break;
-        }
-        else {
-          digitalWrite(LED_BUILTIN, 1);
-          delay(100);
-          Serial.print(".");
-        }
-        yield();
-      }
-      if (!hasConnected) {
-        // Wipe credentials and reset
-        Serial.println("Wifi connect failed, Please try your details again in the captive portal");
-        preferences.begin("scads", false);
-        preferences.putString("wifi", "");
-        preferences.end();
-        ESP.restart();
-      }
+      // Wipe credentials and reset
+      Serial.println("Wifi connect failed, Please try your details again in the captive portal");
+      preferences.begin("scads", false);
+      preferences.putString("wifi", "");
+      preferences.end();
+      ESP.restart();
     }
 
     delay(100);


### PR DESCRIPTION
During startup, the device will kick up the captive portal after 2 mins, every time, regardless if it's connected to the station before or not.